### PR TITLE
we are dedicating an entry point for sdk7

### DIFF
--- a/connection/src/main/java/io/herow/sdk/connection/HerowAPI.kt
+++ b/connection/src/main/java/io/herow/sdk/connection/HerowAPI.kt
@@ -9,8 +9,8 @@ import retrofit2.http.*
 
 interface HerowAPI {
     companion object {
-        const val PRE_PROD_BASE_URL = "https://m-preprod.herow.io"
-        const val PROD_BASE_URL = "https://m.herow.io"
+        const val PRE_PROD_BASE_URL = "https://sdk7-preprod.herow.io"
+        const val PROD_BASE_URL = "https://sdk7.herow.io"
         const val TEST_BASE_URL = "https://herow-sdk-backend-poc.ew.r.appspot.com"
     }
 


### PR DESCRIPTION
2 new entry points are available for the new SDK7.
The main goal is to split traffic and isolate legacy traffic (or the reverse).